### PR TITLE
refactor fe components

### DIFF
--- a/apps/backend/bun.lock
+++ b/apps/backend/bun.lock
@@ -5,6 +5,7 @@
       "name": "app",
       "dependencies": {
         "@elysiajs/cors": "^1.2.0",
+        "@prisma/client": "^6.3.1",
         "elysia": "latest",
       },
       "devDependencies": {
@@ -14,6 +15,8 @@
   },
   "packages": {
     "@elysiajs/cors": ["@elysiajs/cors@1.2.0", "", { "peerDependencies": { "elysia": ">= 1.2.0" } }, "sha512-qsJwDAg6WfdQRMfj6uSMcDPSpXvm/zQFeAX1uuJXhIgazH8itSfcDxcH9pMuXVRX1yQNi2pPwNQLJmAcw5mzvw=="],
+
+    "@prisma/client": ["@prisma/client@6.3.1", "", { "peerDependencies": { "prisma": "*", "typescript": ">=5.1.0" }, "optionalPeers": ["prisma", "typescript"] }, "sha512-ARAJaPs+eBkemdky/XU3cvGRl+mIPHCN2lCXsl5Vlb0E2gV+R6IN7aCI8CisRGszEZondwIsW9Iz8EJkTdykyA=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.16", "", {}, "sha512-rIljj8VPYAfn26ANY+5pCNVBPiv6hSufuKGe46y65cJZpvx8vHvPXlU0Q/Le4OGtlNaL8Jg2FuhtvQX18lSIqA=="],
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@elysiajs/cors": "^1.2.0",
+    "@prisma/client": "^6.3.1",
     "elysia": "latest"
   },
   "devDependencies": {

--- a/apps/database/prisma/schema.prisma
+++ b/apps/database/prisma/schema.prisma
@@ -9,8 +9,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 model Survey {

--- a/apps/frontend/app/components/Survey/Survey.tsx
+++ b/apps/frontend/app/components/Survey/Survey.tsx
@@ -45,7 +45,7 @@ export const Survey: React.FC<SurveyProps> = ({ id, title, description, question
           <input required onChange={(e) => setContent(e.target.value)} className='input bg-white w-full border-slate-200' />
         </div>
       )
-      break;
+      break
     case MODES.RESULTS:
       modeComponent = (
         <div className='flex flex-col w-full'>
@@ -64,7 +64,7 @@ export const Survey: React.FC<SurveyProps> = ({ id, title, description, question
           </div>
         </div>
       )
-    
+      break
   }
 
   return (

--- a/apps/frontend/app/components/SurveyEditMode/SurveyEditMode.tsx
+++ b/apps/frontend/app/components/SurveyEditMode/SurveyEditMode.tsx
@@ -1,9 +1,11 @@
 import { type SurveyEditModeProps } from '../../types'
 import { useState } from 'react'
+import { CREATE_EDIT_MODES } from '../../types'
 import apiClient from 'client'
 
 
 export const SurveyEditMode: React.FC<SurveyEditModeProps> = ({ editing, handleSetEditMode }) => {
+  const [mode, setMode] = useState()
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
   const [question, setQuestion] = useState('')
@@ -18,7 +20,7 @@ export const SurveyEditMode: React.FC<SurveyEditModeProps> = ({ editing, handleS
   }
 
   return (
-    <div className={`${!editing && 'hidden'} p-4 border border-slate-500 rounded-xl flex flex-col gap-4 bg-slate-100 text-black mb-8`}>
+    <div className={`${editing !== CREATE_EDIT_MODES.EDIT && 'hidden'} p-4 border border-slate-500 rounded-xl flex flex-col gap-4 bg-slate-100 text-black mb-8`}>
       <div className='flex flex-col gap-2'>
         <h2 className='text-xl font-bold'>Title</h2>
         <input 

--- a/apps/frontend/app/components/SurveyListView/SurveyListView.tsx
+++ b/apps/frontend/app/components/SurveyListView/SurveyListView.tsx
@@ -1,13 +1,14 @@
 import { useState } from 'react';
 import { Survey } from '../survey/survey';
+import { CREATE_EDIT_MODES } from '~/types';
 import { type SurveyListViewProps } from '~/types';
 import { SurveyEditMode } from '../SurveyEditMode/SurveyEditMode';
 
 export const SurveyListView: React.FC<SurveyListViewProps> = ({ surveys }) => {
-  const [editMode, setEditMode] = useState(false)
+  const [editMode, setEditMode] = useState(CREATE_EDIT_MODES.DEFAULT)
 
-  const handleSetEditMode = ( bool:boolean ) => {
-    setEditMode(bool)
+  const handleSetEditMode = ( mode:CREATE_EDIT_MODES ) => {
+    setEditMode(mode)
   }
   
   return (
@@ -15,7 +16,7 @@ export const SurveyListView: React.FC<SurveyListViewProps> = ({ surveys }) => {
       <div className='mb-8 w-full'>
         <h1 className="text-6xl font-semibold">Survey App</h1>
       </div>
-      <button onClick={() => setEditMode(true)} className={`${editMode && 'hidden'} btn btn-primary w-full mb-8`}>
+      <button onClick={() => setEditMode(CREATE_EDIT_MODES.CREATE)} className={`${editMode === CREATE_EDIT_MODES.CREATE && 'hidden'} btn btn-primary w-full mb-8`}>
           New Survey +
       </button>
       <SurveyEditMode editing={editMode} handleSetEditMode={handleSetEditMode} />

--- a/apps/frontend/app/types.ts
+++ b/apps/frontend/app/types.ts
@@ -10,6 +10,12 @@ export type SurveyListViewProps = {
 }
 
 export type SurveyEditModeProps = {
-    editing: boolean,
-    handleSetEditMode: (bool:boolean) => void
+    editing: string,
+    handleSetEditMode: (mode:strings) => void
 }
+
+export enum CREATE_EDIT_MODES {
+    DEFAULT="Default",
+    CREATE="Create",
+    EDIT="Edit"
+  }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor frontend survey components to use `CREATE_EDIT_MODES` enum, add `@prisma/client` to backend, and update Prisma schema for direct connection.
> 
>   - **Frontend Refactor**:
>     - Introduced `CREATE_EDIT_MODES` enum in `types.ts` and updated `SurveyEditMode.tsx`, `SurveyListView.tsx`, and `Survey.tsx` to use it for managing edit modes.
>     - Changed `handleSetEditMode` function signature in `SurveyListView.tsx` and `SurveyEditMode.tsx` to accept `CREATE_EDIT_MODES` instead of boolean.
>     - Removed semicolons after `break` statements in `Survey.tsx`.
>   - **Backend Changes**:
>     - Added `@prisma/client` dependency in `package.json` and `bun.lock`.
>   - **Prisma Schema Update**:
>     - Added `directUrl` to `datasource db` in `schema.prisma` for direct connection configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fractal-bootcamp%2Fericwang-survey-app&utm_source=github&utm_medium=referral)<sup> for a35a9341e55630830185e84896a8e2b928c1a356. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->